### PR TITLE
Configure WebDriver with Capybara

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+APP_HOST=https://rozetka.com.ua

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,125 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    builder (3.3.0)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+    concurrent-ruby (1.3.4)
+    cucumber (9.2.0)
+      builder (~> 3.2)
+      cucumber-ci-environment (> 9, < 11)
+      cucumber-core (> 13, < 14)
+      cucumber-cucumber-expressions (~> 17.0)
+      cucumber-gherkin (> 24, < 28)
+      cucumber-html-formatter (> 20.3, < 22)
+      cucumber-messages (> 19, < 25)
+      diff-lcs (~> 1.5)
+      mini_mime (~> 1.1)
+      multi_test (~> 1.1)
+      sys-uname (~> 1.2)
+    cucumber-ci-environment (10.0.1)
+    cucumber-core (13.0.3)
+      cucumber-gherkin (>= 27, < 28)
+      cucumber-messages (>= 20, < 23)
+      cucumber-tag-expressions (> 5, < 7)
+    cucumber-cucumber-expressions (17.1.0)
+      bigdecimal
+    cucumber-gherkin (27.0.0)
+      cucumber-messages (>= 19.1.4, < 23)
+    cucumber-html-formatter (21.7.0)
+      cucumber-messages (> 19, < 27)
+    cucumber-messages (22.0.0)
+    cucumber-tag-expressions (6.1.1)
+    diff-lcs (1.5.1)
+    dotenv (3.1.4)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
+    ffi (1.17.0-aarch64-linux-gnu)
+    ffi (1.17.0-aarch64-linux-musl)
+    ffi (1.17.0-arm-linux-gnu)
+    ffi (1.17.0-arm-linux-musl)
+    ffi (1.17.0-arm64-darwin)
+    ffi (1.17.0-x86-linux-gnu)
+    ffi (1.17.0-x86-linux-musl)
+    ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
+    i18n (1.14.6)
+      concurrent-ruby (~> 1.0)
+    logger (1.6.1)
+    matrix (0.4.2)
+    mini_mime (1.1.5)
+    multi_test (1.1.0)
+    nokogiri (1.16.7-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86-linux)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.7-x86_64-linux)
+      racc (~> 1.4)
+    public_suffix (6.0.1)
+    racc (1.8.1)
+    rack (3.1.8)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    regexp_parser (2.9.2)
+    rexml (3.3.9)
+    rubyzip (2.3.2)
+    selenium-webdriver (4.27.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
+    site_prism (5.0.4)
+      addressable (~> 2.8, >= 2.8.4)
+      capybara (~> 3.32)
+      site_prism-all_there (> 2, < 5)
+    site_prism-all_there (3.0.5)
+    sys-uname (1.3.1)
+      ffi (~> 1.1)
+    websocket (1.2.11)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
+
+PLATFORMS
+  aarch64-linux
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
+  x86-linux
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  capybara (~> 3.40)
+  cucumber (~> 9.2.0)
+  dotenv
+  faker (~> 3.5.1)
+  selenium-webdriver
+  site_prism (~> 5.0.3)
+
+BUNDLED WITH
+   2.5.18

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,12 +1,12 @@
 require 'capybara'
 require 'selenium-webdriver'
 require 'capybara/cucumber'
-require 'dotenv/load'
+require 'dotenv'
 
 Dotenv.load
 
 Capybara.configure do |config|
   config.default_driver = :selenium_chrome
-  config.app_host = ENV['APP_HOST'] || 'https://rozetka.com.ua'
+  config.app_host = ENV['APP_HOST']
   config.run_server = false
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,0 +1,12 @@
+require 'capybara'
+require 'selenium-webdriver'
+require 'capybara/cucumber'
+require 'dotenv/load'
+
+Dotenv.load
+
+Capybara.configure do |config|
+  config.default_driver = :selenium_chrome
+  config.app_host = ENV['APP_HOST'] || 'https://rozetka.com.ua'
+  config.run_server = false
+end


### PR DESCRIPTION
### Related Issues: * resolves #1 

### Code reviewers

- [x] @DKrutenk0 

## Description
This PR includes the configuration of WebDriver using Capybara to enable browser automation testing. Specifically, it sets up the capability to open a browser while running automation tests.

## Summary of change
- Created the `support/env.rb` file with Capybara configuration:
  - Set `default_driver` to `:selenium_chrome` for browser automation.
  - Configured `app_host` to point to the test website (`https://rozetka.com.ua`).
  - Disabled the server running, as the tests should operate in browser-only mode.

## How to Test
1. Ensure the required gems are installed by running `bundle install`.
2. Run the tests using a Cucumber command or your preferred test runner:
   ```bash
   cucumber

## CHECK LIST

- [x]  Code runs successfully with no errors.
- [x]  PR is reviewed manually again (to make sure you have 100% ready code)
- [x]  Documentation and code comments are clear and accurate.
- [x]  PR meets all conventions
