### PR TITLE
Refactor: combine search_steps and neg_search_steps into a single file

### DIFF
--- a/features/step_definitions/neg_search_steps.rb
+++ b/features/step_definitions/neg_search_steps.rb
@@ -1,7 +1,0 @@
-Then('I should see a dropdown with no results message') do
-  expect(@homepage).to have_text(Constants::NO_RESULTS_MESSAGE)
-end
-
-Then('I should see the no results message') do
-  expect(@homepage.empty_results_text).to be_visible
-end

--- a/features/step_definitions/search_steps.rb
+++ b/features/step_definitions/search_steps.rb
@@ -30,3 +30,11 @@ end
 Then('the clear button should disappear') do
   expect(@homepage).to have_no_clear_button
 end
+
+Then('I should see a dropdown with no results message') do
+  expect(@homepage).to have_text(Constants::NO_RESULTS_MESSAGE)
+end
+
+Then('I should see the no results message') do
+  expect(@homepage.empty_results_text).to be_visible
+end


### PR DESCRIPTION
## Description
### Related Issues: * resolves #14 
 This PR consolidates `search_steps.rb` and `neg_search_steps.rb` into a single-step definition file, `search_steps.rb`. The purpose is to simplify the codebase by merging step definitions related to the same page functionality.
  
### Summary of change
- Merged steps from `neg_search_steps.rb` into `search_steps.rb`.
- Removed `neg_search_steps.rb` to eliminate redundancy.
- Verified all scenarios from both feature files to ensure they pass successfully.
